### PR TITLE
Add NonExhaustiveReturn warning (closes #14)

### DIFF
--- a/xsc-cli/src/main.rs
+++ b/xsc-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use xsc_core::r#static::info::{gen_errs_from_path, gen_errs_from_src, AstCache, AstMap, Error, SrcCache, TypeEnv};
+use xsc_core::PRELUDE_PATH;
 
 use crate::cli::parse_args;
 use crate::fmt::{print_parse_errs, print_xs_errs};
@@ -18,7 +19,7 @@ fn main() {
     let mut ast_cache = AstMap::new();
     let mut src_cache = AstMap::new();
     
-    let prelude_path = PathBuf::from(r"prelude.xs");
+    let prelude_path = PathBuf::from(PRELUDE_PATH);
     let prelude = include_str!(r"../../xsc-core/prelude.xs");
 
     gen_errs_from_src(&prelude_path, prelude, &mut type_env, &mut ast_cache, &mut src_cache).expect("Prelude can't produce parse errors");

--- a/xsc-core/src/lib.rs
+++ b/xsc-core/src/lib.rs
@@ -2,3 +2,7 @@ pub mod parsing;
 pub mod r#static;
 pub mod utils;
 pub mod doxygen;
+
+// The synthetic path under which the bundled prelude is loaded. Both the CLI
+// and the type-checker compare against this value to identify prelude code.
+pub const PRELUDE_PATH: &str = "prelude.xs";

--- a/xsc-core/src/static/info/xs_error.rs
+++ b/xsc-core/src/static/info/xs_error.rs
@@ -38,6 +38,7 @@ pub enum WarningKind {
     FloatMod = 110,
     InfLoopLim = 111,
     InfRecLim = 112,
+    NonExhaustiveReturn = 113,
 
     InvalidExternDecl = 999,
     UnknownWarningName = 1000,
@@ -204,6 +205,7 @@ impl WarningKind {
             WarningKind::FloatMod            => "FloatMod",
             WarningKind::InfLoopLim          => "InfLoopLim",
             WarningKind::InfRecLim           => "InfRecLim",
+            WarningKind::NonExhaustiveReturn => "NonExhaustiveReturn",
             WarningKind::InvalidExternDecl   => "InvalidExternDecl",
             WarningKind::UnknownWarningName  => "UnknownWarningName",
         }
@@ -224,6 +226,7 @@ impl WarningKind {
             "FloatMod"            => Some(WarningKind::FloatMod),
             "InfLoopLim"          => Some(WarningKind::InfLoopLim),
             "InfRecLim"           => Some(WarningKind::InfRecLim),
+            "NonExhaustiveReturn" => Some(WarningKind::NonExhaustiveReturn),
 
             // InvalidExternDecl and UnknownWarningName cannot be ignored, so it is exlcuded here
             _                     => None

--- a/xsc-core/src/static/type_check/statement.rs
+++ b/xsc-core/src/static/type_check/statement.rs
@@ -19,7 +19,8 @@ use crate::r#static::info::{
     XsError,
 };
 use crate::r#static::type_check::expression::xs_tc_expr;
-use crate::r#static::type_check::util::{chk_rule_opt, combine_results, type_cmp};
+use crate::r#static::type_check::util::{chk_rule_opt, combine_results, returns_on_all_paths, type_cmp};
+use crate::PRELUDE_PATH;
 
 #[allow(clippy::too_many_arguments)]
 pub fn xs_tc_stmt(
@@ -630,14 +631,28 @@ match stmt {
                 )
             })
         );
-        
+
+        // The bundled prelude declares engine-implemented builtins as empty-bodied
+        // stubs (e.g. `bool xsIsRuleEnabled(...) {}`). Skip the check for that
+        // synthetic path so user code with an empty placeholder body still warns.
+        let is_prelude = path == &PathBuf::from(PRELUDE_PATH);
+        if !is_prelude && *return_type != Type::Void && !returns_on_all_paths(body) {
+            type_env.add_err(path, XsError::warning(
+                name_span,
+                "Function {0} declares a {1} return type but does not return on all paths. \
+                XS will emit a runtime error if execution falls off the end of the function.",
+                vec![&name.0, &return_type.to_string()],
+                WarningKind::NonExhaustiveReturn,
+            ));
+        }
+
         type_env.save_fn_env(name);
 
         // restore the old fn env if it existed
         if let Some(env) = old_env {
             type_env.set_fn_env(env);
         };
-        
+
         results
     },
     AstNode::Return(spanned_expr) => {

--- a/xsc-core/src/static/type_check/util.rs
+++ b/xsc-core/src/static/type_check/util.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use chumsky::container::{Container};
 
-use crate::parsing::ast::{Expr, Literal, Type};
+use crate::parsing::ast::{AstNode, Body, Expr, Literal, Type};
 use crate::parsing::span::{Span, Spanned};
 use crate::r#static::type_check::expression::xs_tc_expr;
 use crate::r#static::info::{WarningKind, XsError, TypeEnv};
@@ -283,6 +283,40 @@ pub fn type_cmp(
         }
     };
     errs
+}
+
+// Returns true when every control-flow path through `body` ends in an explicit
+// `return` statement. Conservative: when in doubt, returns false. False negatives
+// (missed warnings) are preferred over false positives (warning on correct code).
+pub fn returns_on_all_paths(body: &Body) -> bool {
+    body.iter().any(stmt_returns)
+}
+
+fn stmt_returns(spanned: &Spanned<AstNode>) -> bool {
+    let (stmt, _) = spanned;
+    match stmt {
+        AstNode::Return(_) => true,
+        AstNode::IfElse { consequent: (cons, _), alternate, .. } => {
+            let alt_returns = match alternate {
+                Some((alt, _)) => returns_on_all_paths(alt),
+                None => false,
+            };
+            returns_on_all_paths(cons) && alt_returns
+        }
+        AstNode::Switch { cases, .. } => {
+            // Sound under both C-style fallthrough and XS-style break semantics:
+            // if every case body unconditionally returns, fallthrough cannot bypass it.
+            // A default case is required, otherwise an unmatched value falls through.
+            let has_default = cases.iter().any(|(discriminant, _)| discriminant.is_none());
+            has_default && cases.iter().all(|(_, (case_body, _))| returns_on_all_paths(case_body))
+        }
+        // Loop bodies may not execute even once, and even `while(true)` is not a
+        // reliable terminator in XS: the runtime caps iterations via
+        // infiniteLoopLimit (see the existing InfLoopLim warning), so a loop can
+        // exit and fall off the end of the function. Conservatively non-returning.
+        AstNode::While { .. } | AstNode::For { .. } => false,
+        _ => false,
+    }
 }
 
 pub fn chk_rule_opt<'src>(


### PR DESCRIPTION
Closes #14.

## What this does

Adds a new warning, `NonExhaustiveReturn` (code 113), that fires when a
function declared with a non-void return type can fall off the end of its
body. XS errors at runtime in that situation, so this is a real footgun
that the linter was previously silent about.

```xs
int sometimesReturns(int x = 0) {
    if (x > 0) {
        return(1);
    }
    // execution falls off the end here, runtime error in XS
}
```

```
[113] Warning: NonExhaustiveReturn
   Function sometimesReturns declares a int return type but does not
   return on all paths. XS will emit a runtime error if execution falls
   off the end of the function.
```

The warning is registered in `WarningKind` so it integrates with the
existing `--ignores` flag and per-line ignore comments
(`/** @ignore NonExhaustiveReturn */`).

## How the analysis works

A new helper `returns_on_all_paths` in `xsc-core/src/static/type_check/util.rs`
walks the AST and recognises the following statements as guaranteeing a
return:

- `Return`: always
- `IfElse`: both branches must return; an `if` without an `else` does not
- `Switch`: every case must return AND a default case must exist (in any
  position, case order is not significant)
- A body sequence: if any statement above appears anywhere in it

Loop bodies (`While`, `For`) are conservatively treated as non-returning,
because XS truncates iterations via `infiniteLoopLimit` and the loop can
exit and fall off the end of the function regardless of what its body does.
This matches the spirit of the existing `InfLoopLim` lint.

The check fires from the `FnDef` arm of the type-checker after the body is
walked, so unrelated type errors inside the body still surface.

## The prelude

The bundled prelude (`xsc-core/prelude.xs`) declares engine-implemented
builtins as empty-bodied stubs, e.g.:

```xs
bool xsIsRuleEnabled(string ruleName = "") {}
vector xsVectorNormalize(vector v = vector(-1, -1, -1)) {}
```

Without special handling, the new check would fire on all of them and trip
the `Prelude can't produce errors` panic in the CLI.

To exempt the prelude without silently accepting user-written empty-bodied
placeholder functions (e.g. `int foo() {}`), the prelude's synthetic load
path is exposed as `xsc_core::PRELUDE_PATH = "prelude.xs"` and the
type-checker gates the warning on `path != prelude_path`. The CLI now
imports the same constant so the two stay in sync.

## Test cases

A standalone `.xs` file with the following cases was used to verify
behaviour. Worth folding into a `tests/` harness as a follow-up.

| Case | Expected | Actual |
|---|---|---|
| `int alwaysReturns()` | pass | pass |
| `int ifElseBoth()` | pass | pass |
| `int nestedIfElse()` | pass | pass |
| `int switchAllReturn()` | pass | pass |
| `int switchDefaultMiddleOk()` | pass | pass |
| `int trailingReturn()` | pass | pass |
| `void voidEmpty()` | pass | pass |
| `int ifNoElse()` | warn | warn |
| `int elseMissing()` | warn | warn |
| `int switchNoDefault()` | warn | warn |
| `int switchOneCaseFalls()` | warn | warn |
| `int switchDefaultMiddle()` | warn | warn |
| `int whileMaybe()` | warn | warn |
| `int forMaybe()` | warn | warn |
| `int userStub() {}` | warn | warn |

`--ignores=NonExhaustiveReturn` correctly suppresses all of them.
`cargo build --release` is clean. `cargo clippy -p xsc-core` introduces no
new warnings on the touched files.

## Known scope limits

- Recursion through `goto`/`LabelDef` is treated conservatively as
  non-returning (false negative, never false positive).
- Functions reached only through `goto` chains are not modelled.
- Dead code after a `return` is not yet flagged. That is a natural
  follow-up but kept out of this PR to stay focused on #14.

// git push --force-with-lease-on-life